### PR TITLE
Zero value reading handling / plance distance argument

### DIFF
--- a/include/depth_calibration/depth_adjuster.h
+++ b/include/depth_calibration/depth_adjuster.h
@@ -27,6 +27,8 @@ protected:
   ros::Publisher pub_calibrated_depth_raw_;
 
   double unknown_depth_distance_;
+  double is_occluded_percentage_;
+  double occluded_distance_;
 
   double border_percentage_top_;
   double border_percentage_bottom_;
@@ -34,7 +36,6 @@ protected:
   double border_percentage_right_;
 
   cv::Mat depth_multiplier_correction_;
-  boost::mutex multiplier_mutex_;
 
   ros::Subscriber sub_camera_info_;
   ros::Publisher pub_camera_info_relay_;

--- a/launch/adjusted_openni2.launch
+++ b/launch/adjusted_openni2.launch
@@ -96,7 +96,7 @@
       
       <arg name="unknown_depth_distance"          value="0.0"/>
       <arg name="is_occluded_percentage"          value="1.0"/>
-      <arg name="occluded_distance"               value="0.1"/>
+      <arg name="occluded_distance"               value="0.0"/>
       
       <arg name="border_percentage_top"           value="0.00"/>
       <arg name="border_percentage_bottom"        value="0.00"/>

--- a/launch/adjusted_openni2.launch
+++ b/launch/adjusted_openni2.launch
@@ -31,7 +31,6 @@
   <arg name="ir"                    default="ir" />
   <arg name="depth"                 default="depth" />
   <arg name="uncalibrated_depth"    default="uncalibrated_depth" />
-  <arg name="calibration_file_path" default="camera_info/depth_calibration.yaml"/>
 
   <!-- Optionally suppress loading the driver nodelet and/or publishing the default tf
        tree. Useful if you are playing back recorded raw data from a bag, or are
@@ -94,8 +93,18 @@
       <arg name="output_depth_raw_topic"          value="$(arg depth)/image_raw" />
       <arg name="input_camera_info_topic"         value="$(arg uncalibrated_depth)/camera_info" />
       <arg name="output_camera_info_relay_topic"  value="$(arg depth)/camera_info" />
-      <arg name="calibration_file_path"           value="$(arg calibration_file_path)"/>      
-      <arg name="enable_adjust" value="true" />
+      
+      <arg name="unknown_depth_distance"          value="0.0"/>
+      <arg name="is_occluded_percentage"          value="1.0"/>
+      <arg name="occluded_distance"               value="0.1"/>
+      
+      <arg name="border_percentage_top"           value="0.00"/>
+      <arg name="border_percentage_bottom"        value="0.00"/>
+      <arg name="border_percentage_left"          value="0.00"/>
+      <arg name="border_percentage_right"         value="0.00"/>
+      
+      <arg name="calibration_file_path"           value="camera_info/depth_calibration.yaml"/>
+      <arg name="enable_adjust"                   value="true" />
     </include>
 
     <!-- Load standard constellation of processing nodelets -->

--- a/launch/depth_adjuster.launch.xml
+++ b/launch/depth_adjuster.launch.xml
@@ -8,6 +8,9 @@
     <arg name="output_camera_info_relay_topic"      default="camera/depth/camera_info"/>
     
     <arg name="unknown_depth_distance"              default="0.0"/>
+    <arg name="is_occluded_percentage"              default="1.0"/> <!-- includes unknown at the borders -->
+    <arg name="occluded_distance"                   default="0.1"/>
+    
     <arg name="border_percentage_top"               default="0.0"/>
     <arg name="border_percentage_bottom"            default="0.0"/>
     <arg name="border_percentage_left"              default="0.0"/>
@@ -24,6 +27,9 @@
         <remap from="output_camera_info_relay"      to="$(arg output_camera_info_relay_topic)"/>
         
         <param name="unknown_depth_distance"        type="double"       value="$(arg unknown_depth_distance)"/>
+        <param name="is_occluded_percentage"        type="double"       value="$(arg is_occluded_percentage)"/>
+        <param name="occluded_distance"             type="double"       value="$(arg occluded_distance)"/> 
+
         <param name="border_percentage_top"         type="double"       value="$(arg border_percentage_top)"/>
         <param name="border_percentage_bottom"      type="double"       value="$(arg border_percentage_bottom)"/>
         <param name="border_percentage_left"        type="double"       value="$(arg border_percentage_left)"/>

--- a/launch/depth_adjuster.launch.xml
+++ b/launch/depth_adjuster.launch.xml
@@ -9,7 +9,7 @@
     
     <arg name="unknown_depth_distance"              default="0.0"/>
     <arg name="is_occluded_percentage"              default="1.0"/> <!-- includes unknown at the borders -->
-    <arg name="occluded_distance"                   default="0.1"/>
+    <arg name="occluded_distance"                   default="0.0"/>
     
     <arg name="border_percentage_top"               default="0.0"/>
     <arg name="border_percentage_bottom"            default="0.0"/>

--- a/launch/depth_calibration.launch
+++ b/launch/depth_calibration.launch
@@ -2,12 +2,14 @@
 <launch>
 	<arg name="info"                   default="/camera/depth/camera_info" />
 	<arg name="depth"                  default="/camera/depth/image_raw" />
-	<arg name="calibration_file_path"  default="camera_info/depth_calibration.yaml"/>
+	<arg name="plane_distance"         default="0.0"/> <!-- 0.0 means use estimation from point cloud -->
+	<arg name="calibration_file_path"  default="camera_info/depth_calibration.yaml"/>	
 
 	<include
 		file="$(find depth_calibration)/launch/depth_calibration.launch.xml">
 		<arg name="camera_info_topic"     value="$(arg info)" />
 		<arg name="depth_raw_topic"       value="$(arg depth)" />
-		<arg name="calibration_file_path" value="$(arg calibration_file_path)" />
+		<arg name="plane_distance"        value="$(arg plane_distance)" />
+		<arg name="calibration_file_path" value="$(arg calibration_file_path)" />		
 	</include>
 </launch>

--- a/launch/depth_calibration.launch.xml
+++ b/launch/depth_calibration.launch.xml
@@ -2,7 +2,8 @@
 <launch>
     <arg name="camera_info_topic"               default="camera/depth/camera_info"/>
     <arg name="depth_raw_topic"                 default="camera/depth/image_raw"/>
-    <arg name="calibration_file_path"           default="camera_info/depth_calibration.yaml"/>
+    <arg name="plane_distance"                  default="0.0"/> <!-- 0.0 means use estimation from point cloud -->
+    <arg name="calibration_file_path"           default="camera_info/depth_calibration.yaml"/>    
 
     <arg name="calibrated_depth_topic"          value="sensor_3d/depth/calibration/depth_calibrated"/>
     <arg name="calibrated_cloud_topic"          value="sensor_3d/depth/calibration/points"/>
@@ -33,6 +34,7 @@
         <remap from="calibrated_cloud"          to="$(arg calibrated_cloud_topic)"/>
         <remap from="save_calibration_trigger"  to="$(arg save_calibration_trigger_topic)"/>
         
+        <param name="plane_distance"            type="double"       value="$(arg plane_distance)"/>
         <param name="calibration_file_path"     type="string"       value="$(arg calibration_file_path)"/>
     </node>
 

--- a/src/depth_adjuster.cpp
+++ b/src/depth_adjuster.cpp
@@ -30,7 +30,7 @@ void DepthAdjuster::onInit()
   unknown_depth_distance_ = unknown_depth_distance_ * 1000; //convert to depth value, which are in mm
 
   private_nh.param("is_occluded_percentage", is_occluded_percentage_, 1.0);
-  private_nh.param("occluded_distance", occluded_distance_, 0.1);
+  private_nh.param("occluded_distance", occluded_distance_, 0.0);
 
   private_nh.param("border_percentage_top", border_percentage_top_, 0.0);
   private_nh.param("border_percentage_bottom", border_percentage_bottom_, 0.0);


### PR DESCRIPTION
Adds distance setting / clearing to zero (= unknown) distance readings
Adds option to set unknown distance to given value only if there are less than x% unknown values

Adds plane distance arg for more accurate calibration
