### PR TITLE
Keep trying to adjust

### DIFF
--- a/src/depth_adjuster.cpp
+++ b/src/depth_adjuster.cpp
@@ -72,11 +72,12 @@ void DepthAdjuster::apply_calibration_cb(const sensor_msgs::ImageConstPtr& depth
       && (depth_msg->width != depth_multiplier_correction_.cols
           || depth_msg->height != depth_multiplier_correction_.rows))
   {
-    ROS_ERROR_STREAM("[Depth adjuster] Calibration file has different resolution than camera depth image");
-    ROS_ERROR_STREAM(
+    ROS_WARN_STREAM_THROTTLE(5.0, "[Depth adjuster] Calibration file has different resolution than camera depth image");
+    ROS_WARN_STREAM_THROTTLE(5.0,
         "[Depth adjuster] Calibration multiplier: " << depth_multiplier_correction_.cols << "x" << depth_multiplier_correction_.rows << ", depth image: " << depth_msg->width << "x" << depth_msg->height);
-    ROS_WARN_STREAM("[Depth adjuster] Skipping depth calibration adjustments.");
-    depth_multiplier_correction_.release();
+    ROS_WARN_STREAM_THROTTLE(5.0, "[Depth adjuster] Skipping depth calibration adjustments (will try again, perhaps camera hasn't reconfigured yet).");
+    pub_calibrated_depth_raw_.publish(depth_msg);
+    return;
   }
 
   cv_bridge::CvImagePtr cv_depth_image;


### PR DESCRIPTION
Even if image and calibration resolution settings do not match.

It takes time for the cameras to reconfigure to the QVGA resolution we use - so sometimes
we get incoming images that have not yet switched from VGA. This patch just lets these
pass through and keeps the depth calibration settings rather than dropping the image
and calibration settings completely.

@AlexReimann do you foresee any problems with letting unmatching images through?
